### PR TITLE
Few Minor Fixes After Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ NOTES:
 
 ## WARNINGS
 
-1. Some of the processes covered hear will examine the contents of HDFS via the Namenode.  The results could spike RPC Queues on clusters that aren't optimized.  I suggest monitoring NN RPC pressure when running large amounts of data through the Hadoop Cli.
+1. Some of the processes covered here will examine the contents of HDFS via the Namenode.  The results could spike RPC Queues on clusters that aren't optimized.  I suggest monitoring NN RPC pressure when running large amounts of data through the Hadoop Cli.
  
 ## Don't skip ME!!
 

--- a/table_dirs_for_conversion.sql
+++ b/table_dirs_for_conversion.sql
@@ -57,6 +57,6 @@ WITH sub AS (
 SELECT
     hdfs_path AS hcli_check
 FROM
-    sub;
+    sub
 WHERE
     conversion != "NO";


### PR DESCRIPTION
Fixing a typo in the documentation, as well as an extra semicolon in a query. These were found while testing using beeline with the queries.