### PR TITLE
Update hms_sqoop_dump.sh

### DIFF
--- a/hms_sqoop_dump.sh
+++ b/hms_sqoop_dump.sh
@@ -73,7 +73,7 @@ if [ "${ORACLE}x" == "x" ]; then
     SELECT="${SELECT} \$CONDITIONS;"
 else
     # Escape the $ and remove the semi-colon.
-    SELECT="${SELECT} \\\$CONDITIONS"
+    SELECT="${SELECT} \$CONDITIONS"
 fi
 
 echo "SELECT: ${SELECT}"


### PR DESCRIPTION
Oracle SELECT stmt had two extra \\ that creates a \ in the final script that is causing parse errors.